### PR TITLE
Add support for untranslated Chromium PiP

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,7 @@ class PipOnTop
      * users that prefer running applications in English */
     let isPipWin = (window.title == 'Picture-in-Picture'
       || window.title == _('Picture-in-Picture')
+      || window.title == 'Picture in picture'
       || window.title.endsWith(' - PiP'));
 
     if (isPipWin || window._isPipAble) {


### PR DESCRIPTION
This adds support for Chromium's PiP window titles. Unfortunately,
adding localization support would be a bit more complex, since Chromium
has a rather...intricate setup for its locale information. At the
moment, though, I figured being English-only was better than nothing.