### PR TITLE
Handle window titles with lowercase 'picture'

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -103,9 +103,9 @@ class PipOnTop
 
     /* Check both translated and untranslated string for
      * users that prefer running applications in English */
-    let isPipWin = (window.title == 'Picture-in-Picture'
+    let isPipWin = (window.title.toLowerCase() == 'picture-in-picture'
       || window.title == _('Picture-in-Picture')
-      || window.title == 'Picture in picture'
+      || window.title.toLowerCase() == 'picture in picture'
       || window.title.endsWith(' - PiP'));
 
     if (isPipWin || window._isPipAble) {


### PR DESCRIPTION
Using Firefox with the Dutch language, the window title ends with a lowercase `picture` and it yields non functional behavior.

![Schermafdruk van 2022-06-30 04-32-56](https://user-images.githubusercontent.com/981494/176581202-3c654b63-e9c0-4cd1-b5e4-51e0467d9904.png)

This MR resolves the issue.

Likely there's a deeper issue with the Dutch translation not being picked up correctly, haven't looked into that.