### PR TITLE
Mark as GNOME 43.alpha compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "name": "PiP on top",
   "settings-schema": "org.gnome.shell.extensions.pip-on-top",
   "shell-version": [
-    "42"
+    "42",
+    "43.alpha"
   ],
   "url": "https://github.com/Rafostar/gnome-shell-extension-pip-on-top",
   "uuid": "pip-on-top@rafostar.github.com",


### PR DESCRIPTION
Works without a hitch in GNOME 43.alpha. No errors nor warnings reported in logs. Workspace toggle tested and works as well.

Using [FCGU](https://gitlab.com/fabiscafe/gnome-unstable) repo and [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) package [gnome-shell-extension-pip-on-top43](https://aur.archlinux.org/packages/gnome-shell-extension-pip-on-top43) to test.

![Schermafdruk van 2022-07-14 23-31-22](https://user-images.githubusercontent.com/981494/179089714-01dbafa6-0e3c-44ac-9b69-ac251825daf6.png)

