### PR TITLE
Add Telegram Wayland Support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,7 +128,9 @@ class PipOnTop
       || window.title == _('Picture-in-Picture')
       || window.title == 'Picture in picture'
       || window.title == 'Picture-in-picture'
-      || window.title.endsWith(' - PiP'));
+      || window.title.endsWith(' - PiP')
+      /* Telegram support */
+      || window.title == 'TelegramDesktop');
 
     if (isPipWin || window._isPipAble) {
       let un = (isPipWin) ? '' : 'un';


### PR DESCRIPTION
Opening videos in Telegram in PiP mode creates a window with the title "TelegramDesktop", while the main Telegram window's title is "Telegram" or "Telegram (*unread messages count*)", so there's no problem making the extension work with Telegram running in Wayland natively (using QT_QPA_PLATFORM=wayland). Tested with latest Telegram Flatpak (v4.2.4)