### PR TITLE
Mark as GNOME 46 compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "name": "PiP on top",
   "settings-schema": "org.gnome.shell.extensions.pip-on-top",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/Rafostar/gnome-shell-extension-pip-on-top",
   "uuid": "pip-on-top@rafostar.github.com",


### PR DESCRIPTION
Tested on Gnome 46 and works as expected.

![Screenshot](https://github.com/Rafostar/gnome-shell-extension-pip-on-top/assets/4900149/f5507097-3e54-4b6c-8ea5-827dce6747b8)