### PR TITLE
Mark as GNOME 47.1 compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "47.1"
   ],
   "url": "https://github.com/Rafostar/gnome-shell-extension-pip-on-top",
   "uuid": "pip-on-top@rafostar.github.com",


### PR DESCRIPTION
Tested on Arch Linux v6.11.6 with Wayland v1.23.1 and Pipewire v1.2.6. No issue detected.