### PR TITLE
Add Collector support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,7 +128,9 @@ export default class PipOnTop extends Extension
       /* Telegram support */
       || window.title == 'TelegramDesktop'
       /* Yandex.Browser support YouTube */
-      || window.title.endsWith(' - YouTube'));
+      || window.title.endsWith(' - YouTube')
+      /* Collector support */
+      || window.title == 'CollectorMainWindow'));
 
     if (isPipWin || window._isPipAble) {
       let un = (isPipWin) ? '' : 'un';


### PR DESCRIPTION
From Collector's description on [Flathub](https://flathub.org/apps/it.mijorus.collector): "Collector is a simple utility that allows you to drag multiple files into a single window and drop them anywhere! It can also download images automatically when pasting urls.".

This pull request allows Collector's window to stay always on top, replicating the behavior of the official, but outdated, [GNOME extension](https://extensions.gnome.org/extension/6685/collector-complementary-extension/).