### PR TITLE
Add Kasasa support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,7 +128,9 @@ export default class PipOnTop extends Extension
       /* Telegram support */
       || window.title == 'TelegramDesktop'
       /* Yandex.Browser support YouTube */
-      || window.title.endsWith(' - YouTube'));
+      || window.title.endsWith(' - YouTube'))
+      /* Kasasa support */
+      || window.title.toLowerCase().includes("kasasa");
 
     if (isPipWin || window._isPipAble) {
       let un = (isPipWin) ? '' : 'un';


### PR DESCRIPTION
From Kasasa's description on [Flathub](https://flathub.org/apps/io.github.kelvinnovais.Kasasa): "Clip and pin what's important to a small floating window, so you don't have to switch between windows or workspaces repeatedly".

This pull request allows Kasasa's window to stay always on top.