### PR TITLE
feat: add support for gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/Rafostar/gnome-shell-extension-pip-on-top",
   "uuid": "pip-on-top@rafostar.github.com",


### PR DESCRIPTION
A quick update to the `metadata.json` to add support for the new Gnome 49.