### PR TITLE
Add support for Google Meet

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -125,6 +125,10 @@ export default class PipOnTop extends Extension
       || window.title == 'Picture in picture'
       || window.title == 'Picture-in-picture'
       || window.title.endsWith(' - PiP')
+      /* Google Meet support */
+      || (window.title.startsWith('Meet -')
+      && (!window.title.endsWith(' Chromium')
+      && !window.title.endsWith(' Firefox')))
       /* Telegram support */
       || window.title == 'TelegramDesktop'
       /* Yandex.Browser support YouTube */


### PR DESCRIPTION
Google Meet Picture-in-Picture windows doesn't get affected by this extension.

Also, these PiP windows doesn't inherit the " - Chromium" ending. Thus, I am filtering on this to not affect the regular "tab".

For instance:
<img width="338" height="475" alt="Screenshot from 2026-02-10 20-34-51" src="https://github.com/user-attachments/assets/51409eae-6613-4557-b98a-618074693664" />

This feature isn't currently available on Mozilla Firefox. However, the modifications should not affect the Meet tabs without PiP under Firefox.

This PR adds support of these windows for "Always on top" state.