### PR TITLE
Adding endsWith(Picture-in-Picture) window title variant

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -125,6 +125,7 @@ export default class PipOnTop extends Extension
       || window.title == 'Picture in picture'
       || window.title == 'Picture-in-picture'
       || window.title.endsWith(' - PiP')
+      || window.title.endsWith('(Picture-in-Picture)')
       /* Telegram support */
       || window.title == 'TelegramDesktop'
       /* Yandex.Browser support YouTube */


### PR DESCRIPTION
On my Ubuntu 24, Gnome 46 window title ends with (Picture-In-Picture) with Chrome and Vivaldi browsers.
I tested it by manually modifying extensions.js and everything works.
I thought that Pull Request could help someone else.
Thanks for your extension