### PR TITLE
feat: add configurable screen corner positioning for PiP windows

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,9 @@
  * Developer: Rafostar
  */
 
+import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class PipOnTop extends Extension
@@ -20,6 +22,12 @@ export default class PipOnTop extends Extension
 
     this._switchWorkspaceId = global.window_manager.connect_after(
       'switch-workspace', this._onSwitchWorkspace.bind(this));
+
+    this._grabOpBeginId = global.display.connect('grab-op-begin', (display, window, grabOp) => {
+      if (window && window._isPipAble && (grabOp === Meta.GrabOp.MOVING || grabOp === Meta.GrabOp.KEYBOARD_MOVING))
+        window._pipUserMoved = true;
+    });
+
     this._onSwitchWorkspace();
   }
 
@@ -29,6 +37,11 @@ export default class PipOnTop extends Extension
     this.settings = null;
 
     global.window_manager.disconnect(this._switchWorkspaceId);
+
+    if (this._grabOpBeginId) {
+      global.display.disconnect(this._grabOpBeginId);
+      this._grabOpBeginId = 0;
+    }
 
     if (this._lastWorkspace) {
       this._lastWorkspace.disconnect(this._windowAddedId);
@@ -100,6 +113,10 @@ export default class PipOnTop extends Extension
       window._notifyPipTitleId = window.connect_after(
         'notify::title', this._checkTitle.bind(this));
     }
+    if (!window._notifyPipSizeId) {
+      window._notifyPipSizeId = window.connect(
+        'size-changed', this._checkTitle.bind(this));
+    }
     this._checkTitle(window);
   }
 
@@ -109,8 +126,73 @@ export default class PipOnTop extends Extension
       window.disconnect(window._notifyPipTitleId);
       window._notifyPipTitleId = null;
     }
+    if (window._notifyPipSizeId) {
+      window.disconnect(window._notifyPipSizeId);
+      window._notifyPipSizeId = null;
+    }
     if (window._isPipAble)
       window._isPipAble = null;
+    if (window._pipUserMoved)
+      window._pipUserMoved = null;
+  }
+
+  _positionWindow(window, attempt = 0)
+  {
+    const corner = this.settings?.get_string('corner');
+    if (!corner || corner === 'disabled' || window._pipUserMoved)
+      return;
+
+    GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      if (!window || window._pipUserMoved)
+        return GLib.SOURCE_REMOVE;
+
+      const monitorIndex = window.get_monitor();
+      if (monitorIndex < 0)
+        return GLib.SOURCE_REMOVE;
+
+      const workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
+      const frameRect = window.get_frame_rect();
+
+      if (!workArea || !frameRect || frameRect.width <= 50 || frameRect.height <= 50) {
+        if (attempt < 10) {
+          GLib.timeout_add(GLib.PRIORITY_DEFAULT_IDLE, 50, () => {
+            if (!window || window._pipUserMoved)
+              return GLib.SOURCE_REMOVE;
+            this._positionWindow(window, attempt + 1);
+            return GLib.SOURCE_REMOVE;
+          });
+        }
+        return GLib.SOURCE_REMOVE;
+      }
+
+      let targetX = workArea.x;
+      let targetY = workArea.y;
+
+      switch (corner) {
+        case 'top-left':
+          targetX = workArea.x;
+          targetY = workArea.y;
+          break;
+        case 'top-right':
+          targetX = workArea.x + workArea.width - frameRect.width;
+          targetY = workArea.y;
+          break;
+        case 'bottom-left':
+          targetX = workArea.x;
+          targetY = workArea.y + workArea.height - frameRect.height;
+          break;
+        case 'bottom-right':
+        default:
+          targetX = workArea.x + workArea.width - frameRect.width;
+          targetY = workArea.y + workArea.height - frameRect.height;
+          break;
+      }
+
+      if (frameRect.x !== targetX || frameRect.y !== targetY)
+        window.move_frame(true, targetX, targetY);
+
+      return GLib.SOURCE_REMOVE;
+    });
   }
 
   _checkTitle(window)
@@ -139,6 +221,9 @@ export default class PipOnTop extends Extension
       /* Change stick if enabled or unstick PipAble windows */
       un = (isPipWin && this.settings.get_boolean('stick')) ? '' : 'un';
       window[`${un}stick`]();
+
+      if (isPipWin)
+        this._positionWindow(window);
     }
   }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -2,7 +2,7 @@ import Adw from 'gi://Adw';
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
-import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 function _addToggle(group, settings, title, key)
 {
@@ -13,6 +13,43 @@ function _addToggle(group, settings, title, key)
   settings.bind(key, toggleRow, 'active',
     Gio.SettingsBindFlags.DEFAULT);
   group.add(toggleRow);
+}
+
+function _addCornerCombo(group, settings, title, key)
+{
+  const options = [
+    { id: 'bottom-right', label: _('Bottom Right') },
+    { id: 'bottom-left', label: _('Bottom Left') },
+    { id: 'top-right', label: _('Top Right') },
+    { id: 'top-left', label: _('Top Left') },
+    { id: 'disabled', label: _('Disabled') },
+  ];
+
+  const stringList = Gtk.StringList.new(options.map(opt => opt.label));
+  const comboRow = new Adw.ComboRow({
+    title: title,
+    model: stringList,
+  });
+
+  const ids = options.map(opt => opt.id);
+  const currentVal = settings.get_string(key);
+  const initialIndex = ids.indexOf(currentVal);
+  if (initialIndex >= 0)
+    comboRow.selected = initialIndex;
+
+  comboRow.connect('notify::selected', () => {
+    const selectedId = ids[comboRow.selected];
+    if (selectedId && settings.get_string(key) !== selectedId)
+      settings.set_string(key, selectedId);
+  });
+
+  settings.connect(`changed::${key}`, () => {
+    const newIdx = ids.indexOf(settings.get_string(key));
+    if (newIdx >= 0 && comboRow.selected !== newIdx)
+      comboRow.selected = newIdx;
+  });
+
+  group.add(comboRow);
 }
 
 export default class PipOnTopPrefs extends ExtensionPreferences {
@@ -26,6 +63,7 @@ export default class PipOnTopPrefs extends ExtensionPreferences {
       });
 
       _addToggle(group, settings, 'Show on all workspaces', 'stick');
+      _addCornerCombo(group, settings, 'Place in screen corner', 'corner');
 
       page.add(group);
       window.add(page);

--- a/schemas/org.gnome.shell.extensions.pip-on-top.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pip-on-top.gschema.xml
@@ -4,5 +4,9 @@
     <key name="stick" type="b">
       <default>false</default>
     </key>
+    <key name="corner" type="s">
+      <default>'bottom-right'</default>
+      <summary>Corner to place the PiP window</summary>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Implement automatically positioning PiP windows to a user configurable corner, while keep the windows manually movable.

Several new custom properties are added to the `window` objects to track new signal handlers and states. This increases the risk of potential name conflicts. Probably we need to move them to a child object `window._pipOnTop` or a `WeakMap` in the extension class.

Close #30.